### PR TITLE
Hack to prevent duplicate modals

### DIFF
--- a/src/networks/EVMContract.ts
+++ b/src/networks/EVMContract.ts
@@ -31,6 +31,8 @@ export class EVMContract extends BaseContract implements IContract {
 
     private ethereumProvider: any;
 
+    private isPayingWithMoonPay: boolean = false;
+
     private chains = {
         [NetworkChain.EVMLocal]: {
             chainId: '0x539',
@@ -167,11 +169,17 @@ export class EVMContract extends BaseContract implements IContract {
 
         if (!wallet) {
             try {
+                if (this.isPayingWithMoonPay) {
+                    return new Promise((resolve, reject) => {
+                        // hang this promise entirely to avoid continuing with the buy function
+                    })
+                }
                 const selectedWallet = await WalletSelector.selectWallet(
                     this.logger
                 );
 
                 if (selectedWallet === PaymentProvider.MoonPay) {
+                    this.isPayingWithMoonPay = true;
                     WalletSelector.openPaymentProcessor(
                         selectedWallet,
                         await this.getMoonPayWidgetUrl(0) // TODO: this only works for 721. We need a way to only show moonpay if someone is purchasing and not just connecting


### PR DESCRIPTION
The whole buy flow assumes a signer-based transaction. MoonPay is not that. At the moment, there are a bunch of bugs colliding and accidentally resulting in success.

1. The buy flow assumes all purchases will be signer-based. Moonpay is not that. If the flow continues after selecting MoonPay, the user will get confusing errors.
2. When the buy flow calls validateBuy, it opens the modal again. It's not supposed to, because the first call to connect was expected to result in a signer.
3. When the modal is opened for that second time, it is behind the MoonPay modal, and cannot be interacted with. As a result, its promise never resolves or rejects. This causes the buy flow to hang, preventing those user errors.

This PR is a total hack. Instead of opening a modal that will return a hanging promise, this PR simply returns a hanging promise in that spot.

The right fix should come very soon. The buy flow should not wait on a promise from that modal. instead, there should be two flows, and the modal should trigger the second half in a way that assumes a signer only for the payment methods that are signer-based.