### PR TITLE
fix: Docs link now points to the correct page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Public client sdk for interacting with HyperMint contracts.
 
-Docs can be found at [https://docs.hypermint.com/client-sdk](https://docs.hypermint.com/developers/sdk)
+Docs can be found at [https://docs.hypermint.com/developers/sdk](https://docs.hypermint.com/developers/sdk)
 
 ## Contributing
 If you spot a problem or wish to contribute to this SDK, either raise a Pull Request or contact support@hypermint.com

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Public client sdk for interacting with HyperMint contracts.
 
-Docs can be found at https://docs.hypermint.com/client-sdk
+Docs can be found at [https://docs.hypermint.com/client-sdk](https://docs.hypermint.com/developers/sdk)
 
 ## Contributing
 If you spot a problem or wish to contribute to this SDK, either raise a Pull Request or contact support@hypermint.com


### PR DESCRIPTION
The previous link was pointing to a 404 page on our doc site.