### PR TITLE
fix: Using location.href vs location.host when deep linking on mobile

### DIFF
--- a/src/wallets/providers/CoinbaseWalletProvider.ts
+++ b/src/wallets/providers/CoinbaseWalletProvider.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import WalletProvider from './WalletProvider';
 
 export default class CoinbaseWalletProvider extends WalletProvider {
-    private readonly deeplinkURL = `https://go.cb-w.com/dapp?cb_url=${window.location.host}`;
+    private readonly deeplinkURL = `https://go.cb-w.com/dapp?cb_url=${window.location.href}`;
 
     public async getWeb3Provider() {
         let coinbaseProvider: any = window?.ethereum?.isCoinbaseWallet

--- a/src/wallets/providers/MetaMaskWalletProvider.ts
+++ b/src/wallets/providers/MetaMaskWalletProvider.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import WalletProvider from './WalletProvider';
 
 export default class MetaMaskWalletProvider extends WalletProvider {
-    private readonly deeplinkURL = `https://metamask.app.link/dapp/${window.location.host}`;
+    private readonly deeplinkURL = `https://metamask.app.link/dapp/${window.location.href}`;
 
     public async getWeb3Provider() {
         let metamaskProvider: any = window?.ethereum?.isMetaMask


### PR DESCRIPTION
Using .host will strip off any trailing page params or folders, and results in users being redirected to the wrong page when using sub pages/folders on mobile experiences.